### PR TITLE
Feature/main 64 add form validation

### DIFF
--- a/features/admin/adding_product_bundles.feature
+++ b/features/admin/adding_product_bundles.feature
@@ -7,7 +7,7 @@ Feature: Creating a product bundle
   Background:
     Given I am logged in as an administrator
 
-  @ui
+  @ui @javascript
   Scenario: creating a new product bundle from an existing product
     Given the store has a product "Smurf2Gold Conversion Machine Bundle"
     When I create a new product bundle

--- a/features/admin/adding_product_bundles.feature
+++ b/features/admin/adding_product_bundles.feature
@@ -5,7 +5,8 @@ Feature: Creating a product bundle
   I want to create a new product bundle via the ui
 
   Background:
-    Given I am logged in as an administrator
+    Given the store operates on a single channel in "United States"
+    And I am logged in as an administrator
 
   @ui @javascript
   Scenario: creating a new product bundle from an existing product

--- a/features/admin/adding_slots_to_product_bundle.feature
+++ b/features/admin/adding_slots_to_product_bundle.feature
@@ -5,7 +5,8 @@ Feature: Browsing product bundle slots in product bundle
   I want to see product bundle slots when looking at a product bundle
 
   Background:
-    Given the store has a product bundle "smurf outfit"
+    Given the store operates on a single channel in "United States"
+    And the store has a product bundle "smurf outfit"
     And the store has a product "smurf hat"
     And I am logged in as an administrator
 

--- a/features/admin/browsing_product_bundles_list.feature
+++ b/features/admin/browsing_product_bundles_list.feature
@@ -5,7 +5,8 @@ Feature: Browsing product bundles list
   I want to see product bundles on an overview page
 
   Background:
-    Given the store has a product "smurf hat"
+    Given the store operates on a single channel in "United States"
+    And the store has a product "smurf hat"
     And the store has a product "smurf house"
     And the store has a product bundle "smurf outfit"
     And I am logged in as an administrator

--- a/features/admin/deleting_product_bundles.feature
+++ b/features/admin/deleting_product_bundles.feature
@@ -5,7 +5,8 @@ As an administrator
 I want to delete an existing product bundle via the ui
 
   Background:
-    Given the store has a product bundle "Smurf Outfit Bundle"
+    Given the store operates on a single channel in "United States"
+    And the store has a product bundle "Smurf Outfit Bundle"
     And I am logged in as an administrator
 
   @ui

--- a/features/admin/deleting_slots_from_product_bundle.feature
+++ b/features/admin/deleting_slots_from_product_bundle.feature
@@ -5,7 +5,8 @@ Feature: Removing slots from a product bundle
   I want to be able to remove previously assigned slots from a product bundle
 
   Background:
-    Given the store has a product "smurf hat"
+    Given the store operates on a single channel in "United States"
+    And the store has a product "smurf hat"
     And the store has a product bundle "smurf outfit"
     And this product bundle has a slot named "headgear" with the "smurf hat" product
     And I am logged in as an administrator

--- a/features/admin/product_bundle_validation.feature
+++ b/features/admin/product_bundle_validation.feature
@@ -16,7 +16,7 @@ Feature: Product bundle validation
     And I try to add it
     Then I should be notified that a product has to be defined
 
-  @ui @todo
+  @ui @javascript
   Scenario: Adding a new product bundle slot without specifying a slot name
     When I try to create a new product bundle
     And I associate the product "smurf hat" with its bundle

--- a/features/admin/product_bundle_validation.feature
+++ b/features/admin/product_bundle_validation.feature
@@ -1,0 +1,27 @@
+@managing_product_bundles
+Feature: Product bundle validation
+  In order to avoid making mistakes when managing a product bundle
+  As an Administrator
+  I want to be prevented from adding or editing it without specifying required fields
+
+  Background:
+    Given the store has a product "smurf hat"
+    And the store has a product bundle "smurf outfit"
+    And this product bundle has a slot named "headgear" with the "smurf hat" product
+    And I am logged in as an administrator
+
+  @ui @todo
+  Scenario: Adding a new product bundle without specifying a product
+    When I try to create a new product bundle
+    And I try to add it
+    Then I should be notified that a product has to be defined
+
+  @ui @todo
+  Scenario: Adding a new product bundle slot without specifying a slot name
+    When I try to create a new product bundle
+    And I associate the product "smurf hat" with its bundle
+    And I add an empty slot
+    And I try to add it
+    Then I should be notified that name is required
+
+

--- a/features/admin/product_bundle_validation.feature
+++ b/features/admin/product_bundle_validation.feature
@@ -10,11 +10,11 @@ Feature: Product bundle validation
     And this product bundle has a slot named "headgear" with the "smurf hat" product
     And I am logged in as an administrator
 
-  @ui @todo
+  @ui @javascript
   Scenario: Adding a new product bundle without specifying a product
     When I try to create a new product bundle
     And I try to add it
-    Then I should be notified that a product has to be defined
+    Then I should be notified that "product" is required
 
   @ui @javascript
   Scenario: Adding a new product bundle slot without specifying a slot name

--- a/features/admin/product_bundle_validation.feature
+++ b/features/admin/product_bundle_validation.feature
@@ -22,7 +22,7 @@ Feature: Product bundle validation
     And I associate the product "smurf hat" with its bundle
     And I add an empty slot
     And I try to add it
-    Then I should be notified that name is required
+    Then I should be notified that "slot name 0" is required
 
   @ui @todo
   Scenario: Adding a new product bundle slot for an existing product bundle

--- a/features/admin/product_bundle_validation.feature
+++ b/features/admin/product_bundle_validation.feature
@@ -24,4 +24,11 @@ Feature: Product bundle validation
     And I try to add it
     Then I should be notified that name is required
 
+  @ui @todo
+  Scenario: Adding a new product bundle slot for an existing product bundle
+    When I try to create a new product bundle
+    And I associate the product "smurf outfit" with its bundle
+    And I try to add it
+    Then I should be notified that this product is already defined as product bundle
+
 

--- a/features/admin/product_bundle_validation.feature
+++ b/features/admin/product_bundle_validation.feature
@@ -14,7 +14,7 @@ Feature: Product bundle validation
   Scenario: Adding a new product bundle without specifying a product
     When I try to create a new product bundle
     And I try to add it
-    Then I should be notified that "product" is required
+    Then I should be notified that a product has to be defined
 
   @ui @javascript
   Scenario: Adding a new product bundle slot without specifying a slot name

--- a/features/admin/product_bundle_validation.feature
+++ b/features/admin/product_bundle_validation.feature
@@ -5,7 +5,8 @@ Feature: Product bundle validation
   I want to be prevented from adding or editing it without specifying required fields
 
   Background:
-    Given the store has a product "smurf hat"
+    Given the store operates on a single channel in "United States"
+    And the store has a product "smurf hat"
     And the store has a product bundle "smurf outfit"
     And this product bundle has a slot named "headgear" with the "smurf hat" product
     And I am logged in as an administrator

--- a/src/Entity/ProductBundleSlot.php
+++ b/src/Entity/ProductBundleSlot.php
@@ -19,8 +19,8 @@ class ProductBundleSlot implements ProductBundleSlotInterface, ResourceInterface
     /** @var int */
     private $id;
 
-    /** @var string */
-    private $name = '';
+    /** @var null|string */
+    private $name;
 
     /** @var int */
     private $position = 0;
@@ -41,7 +41,7 @@ class ProductBundleSlot implements ProductBundleSlotInterface, ResourceInterface
         return $this->id;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/src/Entity/ProductBundleSlot.php
+++ b/src/Entity/ProductBundleSlot.php
@@ -56,9 +56,9 @@ class ProductBundleSlot implements ProductBundleSlotInterface, ResourceInterface
         return $this->position;
     }
 
-    public function setPosition(int $position): void
+    public function setPosition(?int $position): void
     {
-        $this->position = $position;
+        $this->position = (int) $position;
     }
 
     public function getBundle(): ?ProductBundleInterface

--- a/src/Entity/ProductBundleSlot.php
+++ b/src/Entity/ProductBundleSlot.php
@@ -19,7 +19,7 @@ class ProductBundleSlot implements ProductBundleSlotInterface, ResourceInterface
     /** @var int */
     private $id;
 
-    /** @var null|string */
+    /** @var string|null */
     private $name;
 
     /** @var int */

--- a/src/Entity/ProductBundleSlotInterface.php
+++ b/src/Entity/ProductBundleSlotInterface.php
@@ -16,7 +16,7 @@ interface ProductBundleSlotInterface
 {
     public function getId(): int;
 
-    public function getName(): string;
+    public function getName(): ?string;
 
     public function setName(string $name): void;
 

--- a/src/Entity/ProductBundleSlotInterface.php
+++ b/src/Entity/ProductBundleSlotInterface.php
@@ -22,7 +22,7 @@ interface ProductBundleSlotInterface
 
     public function getPosition(): int;
 
-    public function setPosition(int $position): void;
+    public function setPosition(?int $position): void;
 
     public function getBundle(): ?ProductBundleInterface;
 

--- a/src/Form/Type/ProductBundleSlotType.php
+++ b/src/Form/Type/ProductBundleSlotType.php
@@ -16,13 +16,17 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 class ProductBundleSlotType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('name', TextType::class, ['label' => 'sylius.ui.name'])
+            ->add('name', TextType::class, [
+                'label' => 'sylius.ui.name',
+                'constraints' => [new NotBlank()]
+            ])
             ->add('products', ProductAutocompleteChoiceType::class, [
                 'label' => 'sylius.ui.products',
                 'multiple' => true,

--- a/src/Form/Type/ProductBundleSlotType.php
+++ b/src/Form/Type/ProductBundleSlotType.php
@@ -13,6 +13,7 @@ namespace solutionDrive\SyliusProductBundlesPlugin\Form\Type;
 use solutionDrive\SyliusProductBundlesPlugin\Entity\ProductBundleSlot;
 use Sylius\Bundle\ProductBundle\Form\Type\ProductAutocompleteChoiceType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -32,6 +33,9 @@ class ProductBundleSlotType extends AbstractType
                 'multiple' => true,
                 'by_reference' => false,
                 'required' => false,
+            ])
+            ->add('position', IntegerType::class,[
+                'label' => 'solutiondrive.ui.position'
             ])
         ;
     }

--- a/src/Form/Type/ProductBundleSlotType.php
+++ b/src/Form/Type/ProductBundleSlotType.php
@@ -25,7 +25,7 @@ class ProductBundleSlotType extends AbstractType
         $builder
             ->add('name', TextType::class, [
                 'label' => 'sylius.ui.name',
-                'constraints' => [new NotBlank()]
+                'constraints' => [new NotBlank()],
             ])
             ->add('products', ProductAutocompleteChoiceType::class, [
                 'label' => 'sylius.ui.products',

--- a/src/Form/Type/ProductBundleSlotType.php
+++ b/src/Form/Type/ProductBundleSlotType.php
@@ -34,8 +34,8 @@ class ProductBundleSlotType extends AbstractType
                 'by_reference' => false,
                 'required' => false,
             ])
-            ->add('position', IntegerType::class,[
-                'label' => 'solutiondrive.ui.position'
+            ->add('position', IntegerType::class, [
+                'label' => 'solutiondrive.ui.position',
             ])
         ;
     }

--- a/src/Form/Type/ProductBundleType.php
+++ b/src/Form/Type/ProductBundleType.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace solutionDrive\SyliusProductBundlesPlugin\Form\Type;
 
-use Sylius\Bundle\ProductBundle\Form\Type\ProductChoiceType;
+use Sylius\Bundle\ProductBundle\Form\Type\ProductAutocompleteChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -20,7 +20,7 @@ class ProductBundleType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('product', ProductChoiceType::class, ['label' => 'sylius.ui.product'])
+            ->add('product', ProductAutocompleteChoiceType::class, ['label' => 'sylius.ui.product'])
             ->add('slots', CollectionType::class, [
                 'entry_type' => ProductBundleSlotType::class,
                 'allow_add' => true,

--- a/src/Form/Type/ProductBundleType.php
+++ b/src/Form/Type/ProductBundleType.php
@@ -14,13 +14,18 @@ use Sylius\Bundle\ProductBundle\Form\Type\ProductAutocompleteChoiceType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 class ProductBundleType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('product', ProductAutocompleteChoiceType::class, ['label' => 'sylius.ui.product'])
+            ->add('product', ProductAutocompleteChoiceType::class, [
+                'label' => 'sylius.ui.product',
+                'required' => true,
+                'constraints' => [new NotBlank()]
+            ])
             ->add('slots', CollectionType::class, [
                 'entry_type' => ProductBundleSlotType::class,
                 'allow_add' => true,

--- a/src/Form/Type/ProductBundleType.php
+++ b/src/Form/Type/ProductBundleType.php
@@ -24,7 +24,7 @@ class ProductBundleType extends AbstractType
             ->add('product', ProductAutocompleteChoiceType::class, [
                 'label' => 'sylius.ui.product',
                 'required' => true,
-                'constraints' => [new NotBlank()]
+                'constraints' => [new NotBlank()],
             ])
             ->add('slots', CollectionType::class, [
                 'entry_type' => ProductBundleSlotType::class,

--- a/src/Resources/config/doctrine/ProductBundle.orm.yml
+++ b/src/Resources/config/doctrine/ProductBundle.orm.yml
@@ -23,7 +23,7 @@ solutionDrive\SyliusProductBundlesPlugin\Entity\ProductBundle:
             joinColumn:
                 name: presentation_slot_id
                 referencedColumnName: id
-                onDelete: 'CASCADE'
+                onDelete: 'SET NULL'
 
     oneToMany:
         slots:

--- a/src/Resources/config/doctrine/ProductBundle.orm.yml
+++ b/src/Resources/config/doctrine/ProductBundle.orm.yml
@@ -31,3 +31,5 @@ solutionDrive\SyliusProductBundlesPlugin\Entity\ProductBundle:
             mappedBy: bundle
             cascade: ["persist"]
             orphanRemoval: true
+            orderBy:
+                position: ASC

--- a/src/Resources/config/grids.yml
+++ b/src/Resources/config/grids.yml
@@ -12,6 +12,11 @@ sylius_grid:
                 product.code:
                     type: string
                     label: sylius.ui.code
+                slots:
+                    type: twig
+                    label: solutiondrive.ui.slots
+                    options:
+                        template: "@SolutionDriveSyliusProductBundlesPlugin/Admin/ProductBundle/Grid/Field/slots.html.twig"
             actions:
                 main:
                     create:

--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -8,3 +8,4 @@ solutiondrive:
         product_bundle: Produkt Bundle
         slots: Slots
         add_slot: Slot hinzufügen
+        position: Position

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -8,3 +8,4 @@ solutiondrive:
         product_bundle: Product Bundle
         slots: Slots
         add_slot: Add slot
+        position: Position

--- a/src/Resources/views/Admin/ProductBundle/Grid/Field/slots.html.twig
+++ b/src/Resources/views/Admin/ProductBundle/Grid/Field/slots.html.twig
@@ -1,0 +1,5 @@
+<div class="ui list">
+    {% for slot in data %}
+        <div class="item">{{ slot.name }}</div>
+    {% endfor %}
+</div>

--- a/src/Resources/views/Admin/ProductBundle/_form.html.twig
+++ b/src/Resources/views/Admin/ProductBundle/_form.html.twig
@@ -44,9 +44,10 @@
 {% macro collection_item(form, allow_delete, button_delete_label, index) %}
     {% spaceless %}
         <div class="ui segment" data-form-collection="item" data-form-collection-index="{{ index }}" data-qa="slot-form-section">
-            <div class="two fields">
-                <div class="field">{{ form_row(form.name) }}</div>
-                <div class="field">{{ form_row(form.products) }}</div>
+            <div class="fields">
+                <div class="seven wide field">{{ form_row(form.name) }}</div>
+                <div class="seven wide field">{{ form_row(form.products) }}</div>
+                <div class="two wide field">{{ form_row(form.position) }}</div>
                 {% if allow_delete %}
                     <div class="one wide field">
                         <label>&nbsp;</label>

--- a/tests/Behat/Context/Ui/Admin/ManagingProductBundlesContext.php
+++ b/tests/Behat/Context/Ui/Admin/ManagingProductBundlesContext.php
@@ -187,6 +187,6 @@ class ManagingProductBundlesContext implements Context
      */
     public function iShouldBeNotifiedThatElementIsRequired(string $element): void
     {
-        Assert::same($this->updatePage->getValidationMessage($element), sprintf('Please enter province %s.', $element));
+        Assert::same($this->updatePage->getValidationMessage($element), 'This value should not be blank.');
     }
 }

--- a/tests/Behat/Context/Ui/Admin/ManagingProductBundlesContext.php
+++ b/tests/Behat/Context/Ui/Admin/ManagingProductBundlesContext.php
@@ -86,7 +86,7 @@ class ManagingProductBundlesContext implements Context
      */
     public function iAssociateTheProductWithItsBundle(ProductInterface $product): void
     {
-        $this->createPage->specifyProductName($product->getName());
+        $this->createPage->specifyProductBundleProduct($product->getCode());
     }
 
     /**

--- a/tests/Behat/Context/Ui/Admin/ManagingProductBundlesContext.php
+++ b/tests/Behat/Context/Ui/Admin/ManagingProductBundlesContext.php
@@ -65,6 +65,7 @@ class ManagingProductBundlesContext implements Context
 
     /**
      * @When I create a new product bundle
+     * @When I try to create a new product bundle
      */
     public function iCreateANewProductBundle(): void
     {
@@ -73,6 +74,7 @@ class ManagingProductBundlesContext implements Context
 
     /**
      * @When I add it
+     * @When I try to add it
      */
     public function iAddIt(): void
     {
@@ -125,8 +127,9 @@ class ManagingProductBundlesContext implements Context
 
     /**
      * @When I add the slot :slotName
+     * @When I add an empty slot
      */
-    public function iAddTheSlot(string $slotName): void
+    public function iAddTheSlot(string $slotName = ''): void
     {
         $this->updatePage->addSlot($slotName);
     }
@@ -166,7 +169,7 @@ class ManagingProductBundlesContext implements Context
     /**
      * @When I remove the slot named :slotName
      */
-    public function iRemoveTheSlotNamed($slotName)
+    public function iRemoveTheSlotNamed($slotName): void
     {
         $this->updatePage->removeSlot($slotName);
     }
@@ -174,8 +177,16 @@ class ManagingProductBundlesContext implements Context
     /**
      * @Then I should see the product bundle has no slot named :slotName
      */
-    public function iShouldSeeTheProductBundleHasNoSlotNamed(string $slotName)
+    public function iShouldSeeTheProductBundleHasNoSlotNamed(string $slotName): void
     {
         Assert::keyNotExists($this->updatePage->getSlotSubForms(), $slotName);
+    }
+
+    /**
+     * @Then I should be notified that :element is required
+     */
+    public function iShouldBeNotifiedThatElementIsRequired(string $element): void
+    {
+        Assert::same($this->updatePage->getValidationMessage($element), sprintf('Please enter province %s.', $element));
     }
 }

--- a/tests/Behat/Context/Ui/Admin/ManagingProductBundlesContext.php
+++ b/tests/Behat/Context/Ui/Admin/ManagingProductBundlesContext.php
@@ -189,4 +189,12 @@ class ManagingProductBundlesContext implements Context
     {
         Assert::same($this->updatePage->getValidationMessage($element), 'This value should not be blank.');
     }
+
+    /**
+     * @Then I should be notified that a product has to be defined
+     */
+    public function iShouldBeNotifiedThatAProductHasToBeDefined()
+    {
+        Assert::same($this->createPage->getValidationMessage('product'), 'This value should not be blank.');
+    }
 }

--- a/tests/Behat/Page/ProductBundles/CreatePage.php
+++ b/tests/Behat/Page/ProductBundles/CreatePage.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\solutionDrive\SyliusProductBundlesPlugin\Behat\Page\ProductBundles;
 
+use Behat\Mink\Driver\Selenium2Driver;
 use Sylius\Behat\Page\Admin\Crud\CreatePage as CrudCreatePage;
+use Webmozart\Assert\Assert;
 
 /**
  * Created by solutionDrive GmbH
@@ -13,13 +15,19 @@ use Sylius\Behat\Page\Admin\Crud\CreatePage as CrudCreatePage;
  */
 final class CreatePage extends CrudCreatePage
 {
-    public function specifyProductId($id)
-    {
-        $this->getDocument()->selectFieldOption('Product', $id);
-    }
 
-    public function specifyProductName($name)
+    public function specifyProductBundleProduct(string $productCode)
     {
-        $this->getDocument()->selectFieldOption('Product', $name);
+        Assert::isInstanceOf($this->getDriver(), Selenium2Driver::class);
+        $dropdown = $this->getDocument()->find('css', '#product_bundle_product')->getParent();
+
+        Assert::notNull($dropdown);
+        $dropdown->click();
+        $dropdown->waitFor(5, function () use ($productCode, $dropdown) {
+            return $dropdown->has('css', '.item[data-value="' . $productCode . '"]');
+        });
+
+        $item = $dropdown->find('css', '.item[data-value="' . $productCode . '"]');
+        $item->click();
     }
 }

--- a/tests/Behat/Page/ProductBundles/CreatePage.php
+++ b/tests/Behat/Page/ProductBundles/CreatePage.php
@@ -19,9 +19,7 @@ final class CreatePage extends CrudCreatePage
     public function specifyProductBundleProduct(string $productCode)
     {
         Assert::isInstanceOf($this->getDriver(), Selenium2Driver::class);
-        $dropdown = $this->getDocument()->find('css', '#product_bundle_product')->getParent();
-
-        Assert::notNull($dropdown);
+        $dropdown = $this->getElement('product')->getParent();
         $dropdown->click();
         $dropdown->waitFor(5, function () use ($productCode, $dropdown) {
             return $dropdown->has('css', '.item[data-value="' . $productCode . '"]');

--- a/tests/Behat/Page/ProductBundles/CreatePage.php
+++ b/tests/Behat/Page/ProductBundles/CreatePage.php
@@ -30,4 +30,11 @@ final class CreatePage extends CrudCreatePage
         $item = $dropdown->find('css', '.item[data-value="' . $productCode . '"]');
         $item->click();
     }
+
+    protected function getDefinedElements(): array
+    {
+        return [
+            'product' => '#product_bundle_product'
+        ];
+    }
 }

--- a/tests/Behat/Page/ProductBundles/CreatePage.php
+++ b/tests/Behat/Page/ProductBundles/CreatePage.php
@@ -19,20 +19,21 @@ final class CreatePage extends CrudCreatePage
     public function specifyProductBundleProduct(string $productCode)
     {
         Assert::isInstanceOf($this->getDriver(), Selenium2Driver::class);
-        $dropdown = $this->getElement('product')->getParent();
-        $dropdown->click();
-        $dropdown->waitFor(5, function () use ($productCode, $dropdown) {
-            return $dropdown->has('css', '.item[data-value="' . $productCode . '"]');
+        $productCodeItemLocator = '.item[data-value="' . $productCode . '"]';
+        $this->getElement('product')->click();
+        $this->getElement('product')->waitFor(10, function () use ($productCodeItemLocator) {
+            return $this->getElement('product')->has('css', $productCodeItemLocator);
         });
 
-        $item = $dropdown->find('css', '.item[data-value="' . $productCode . '"]');
-        $item->click();
+        $this->getElement('product')
+            ->find('css', $productCodeItemLocator)
+            ->click();
     }
 
     protected function getDefinedElements(): array
     {
         return [
-            'product' => '#product_bundle_product'
+            'product' => '.field > label:contains("Product") ~ .sylius-autocomplete'
         ];
     }
 }

--- a/tests/Behat/Page/ProductBundles/UpdatePage.php
+++ b/tests/Behat/Page/ProductBundles/UpdatePage.php
@@ -91,6 +91,4 @@ class UpdatePage extends CrudUpdatePage
             'slot_name_0' => '#product_bundle_slots_0_name'
         ];
     }
-
-
 }

--- a/tests/Behat/Page/ProductBundles/UpdatePage.php
+++ b/tests/Behat/Page/ProductBundles/UpdatePage.php
@@ -84,4 +84,13 @@ class UpdatePage extends CrudUpdatePage
 
         return $slotSubForms[$slotName];
     }
+
+    protected function getDefinedElements(): array
+    {
+        return [
+            'slot_name_0' => '#product_bundle_slots_0_name'
+        ];
+    }
+
+
 }

--- a/tests/Behat/Page/ProductBundles/UpdatePage.php
+++ b/tests/Behat/Page/ProductBundles/UpdatePage.php
@@ -31,15 +31,16 @@ class UpdatePage extends CrudUpdatePage
     {
         Assert::isInstanceOf($this->getDriver(), Selenium2Driver::class);
         $slotSubForm = $this->getSlotSubForm($slotName);
-        $dropdown = $slotSubForm->find('css', '.sylius-autocomplete');
-        Assert::notNull($dropdown);
-        $dropdown->click();
+        $dropDown = $slotSubForm->find('css', '.sylius-autocomplete');
+        Assert::notNull($dropDown);
+        $dropDown->click();
         foreach ($productCodes as $productCode) {
-            $dropdown->waitFor(5, function () use ($productCode, $dropdown) {
-                return $dropdown->has('css', '.item[data-value="' . $productCode . '"]');
+            $productCodeItemLocator = '.item[data-value="' . $productCode . '"]';
+            $dropDown->waitFor(5, function () use ($productCodeItemLocator, $dropDown) {
+                return $dropDown->has('css', $productCodeItemLocator);
             });
 
-            $item = $dropdown->find('css', '.item[data-value="' . $productCode . '"]');
+            $item = $dropDown->find('css', $productCodeItemLocator);
             $item->click();
         }
     }

--- a/tests/Behat/Resources/suites.yml
+++ b/tests/Behat/Resources/suites.yml
@@ -8,6 +8,7 @@ default:
                 - sylius.behat.context.transform.shared_storage
 
                 - sylius.behat.context.setup.admin_security
+                - sylius.behat.context.setup.channel
                 - sylius.behat.context.setup.product
 
                 - solutiondrive.syliusproductbundlesplugin.behat.context.setup.product_bundles


### PR DESCRIPTION
- [ADDED] Display slot position input field
- [ADDED] Form validation: Empty slot name or missing product association will throw an validation error
- [ADDED] Display slot names in grid
- [ADDED] 'Given channel ..' - background step  for behat scenarios
- [CHANGED] Use ProductAutocompleteChoiceType instead of ProductChoiceType for product bundle product
- [CHANGED] Order slots  (per default) by position (ASC)
- [FIXED] Deleting of the presentation slot no longer causes deletion of product bundle

